### PR TITLE
Fix the /meta/nouns text template

### DIFF
--- a/internal/meta/noun_data_source.go
+++ b/internal/meta/noun_data_source.go
@@ -31,7 +31,8 @@ import (
 const NounsName = "/meta/nouns"
 
 var nounsTextTemplate = template.Must(template.New("meta_nouns_text").Parse(strings.TrimSpace(`
-{{ define "get" }}Data Sources:{{ range $name, $info := . }}{{ $name }} formats: {{ $info.Formats }}
+{{ define "get" }}Data Sources:
+{{ range $name, $info := . }}{{ $name }} formats: {{ $info.Formats }}
 {{ end }}{{ end }}
 `)))
 


### PR DESCRIPTION
- there was a missing new line in the template, causing the "Data Sources:" header to run together with the first source
- now there's a test to validate the text template's output
