### PR TITLE
Improve tracer output

### DIFF
--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -314,8 +314,15 @@ func (rec record) String() string {
 			rec.Type.MarkString(), rec.Time, rec.IDString(),
 			rec.Name, rec.Args)
 	default:
-		return fmt.Sprintf("%s %s [%s] %s: %s",
-			rec.Type.MarkString(), rec.Time, rec.IDString(),
-			rec.Name, rec.Args)
+		switch rec.Type {
+		case beginRecord:
+			return fmt.Sprintf("%s %s [%s] %s: %s",
+				rec.Type.MarkString(), rec.Time, rec.IDString(),
+				rec.Name, rec.Args)
+		default:
+			return fmt.Sprintf("%s %s [%s] %s",
+				rec.Type.MarkString(), rec.Time, rec.IDString(),
+				rec.Args)
+		}
 	}
 }

--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -247,11 +247,11 @@ func (t recordType) String() string {
 func (t recordType) MarkString() string {
 	switch t {
 	case beginRecord:
-		return ">>>"
+		return "-->"
 	case infoRecord:
 		return "..."
 	case endRecord:
-		return "<<<"
+		return "<--"
 	case errRecord:
 		return "!!!"
 	default:

--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -130,6 +130,12 @@ func MaybeScope(name string) *TraceScope {
 // TODO: better do this
 var lastTraceId uint64
 
+// ResetTraceID resets the last trace id; this is intended to be used only for
+// test stability.
+func ResetTraceID() {
+	atomic.StoreUint64(&lastTraceId, 0)
+}
+
 // TraceScope represents a traced scope, such as a function call, or an
 // iteration of a worker goroutine loop.
 type TraceScope struct {

--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -308,14 +308,14 @@ func (rec record) IDString() string {
 }
 
 func (rec record) String() string {
-	var format string
-	if _, isCallArgs := rec.Args.(callArgs); isCallArgs {
-		format = "%s %s [%s] %s(%s)"
-	} else {
-		format = "%s %s [%s] %s: %s"
+	switch rec.Args.(type) {
+	case callArgs:
+		return fmt.Sprintf("%s %s [%s] %s(%s)",
+			rec.Type.MarkString(), rec.Time, rec.IDString(),
+			rec.Name, rec.Args)
+	default:
+		return fmt.Sprintf("%s %s [%s] %s: %s",
+			rec.Type.MarkString(), rec.Time, rec.IDString(),
+			rec.Name, rec.Args)
 	}
-	// .Format(time.RFC3339Nano),
-	return fmt.Sprintf(format,
-		rec.Type.MarkString(), rec.Time, rec.IDString(),
-		rec.Name, rec.Args)
 }

--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -190,9 +190,9 @@ func (sc *TraceScope) OpenCall(args ...interface{}) *TraceScope {
 	return sc.emitRecord(beginRecord, callArgs(args))
 }
 
-// CloseCall emits a begin record for a function call with the given arguments.
-func (sc *TraceScope) CloseCall(args ...interface{}) *TraceScope {
-	return sc.emitRecord(endRecord, callArgs(args))
+// CloseCall emits an end record for a function call with the return values.
+func (sc *TraceScope) CloseCall(rets ...interface{}) *TraceScope {
+	return sc.emitRecord(endRecord, callRets(rets))
 }
 
 func (sc *TraceScope) emitRecord(t recordType, args interface{}) *TraceScope {
@@ -271,6 +271,12 @@ func (args callArgs) String() string {
 	return dumpArgs(args)
 }
 
+type callRets []interface{}
+
+func (args callRets) String() string {
+	return dumpArgs(args)
+}
+
 type errArgs struct {
 	name  string
 	err   error
@@ -313,6 +319,10 @@ func (rec record) String() string {
 		return fmt.Sprintf("%s %s [%s] %s(%s)",
 			rec.Type.MarkString(), rec.Time, rec.IDString(),
 			rec.Name, rec.Args)
+	case callRets:
+		return fmt.Sprintf("%s %s [%s] return %s",
+			rec.Type.MarkString(), rec.Time, rec.IDString(),
+			rec.Args)
 	default:
 		switch rec.Type {
 		case beginRecord:

--- a/source/tap/tracer_test.go
+++ b/source/tap/tracer_test.go
@@ -41,18 +41,18 @@ func TestTracer_collatz(t *testing.T) {
 	sc.Close(n)
 	require.Equal(t, 1, n)
 	assert.Equal(t, recodeTimeField(wat.AllStrings()), []string{
-		">>> t0 [1::1] collatzTest: ",
-		">>> t1 [1:1:2] collatz: 5",
-		"<<< t2 [1:1:2] collatz: 16",
-		">>> t3 [1:2:3] collatz: 16",
-		"<<< t4 [1:2:3] collatz: 8",
-		">>> t5 [1:3:4] collatz: 8",
-		"<<< t6 [1:3:4] collatz: 4",
-		">>> t7 [1:4:5] collatz: 4",
-		"<<< t8 [1:4:5] collatz: 2",
-		">>> t9 [1:5:6] collatz: 2",
-		"<<< t10 [1:5:6] collatz: 1",
-		"<<< t11 [1::1] collatzTest: 1",
+		"--> t0 [1::1] collatzTest: ",
+		"--> t1 [1:1:2] collatz: 5",
+		"<-- t2 [1:1:2] collatz: 16",
+		"--> t3 [1:2:3] collatz: 16",
+		"<-- t4 [1:2:3] collatz: 8",
+		"--> t5 [1:3:4] collatz: 8",
+		"<-- t6 [1:3:4] collatz: 4",
+		"--> t7 [1:4:5] collatz: 4",
+		"<-- t8 [1:4:5] collatz: 2",
+		"--> t9 [1:5:6] collatz: 2",
+		"<-- t10 [1:5:6] collatz: 1",
+		"<-- t11 [1::1] collatzTest: 1",
 	})
 }
 

--- a/source/tap/tracer_test.go
+++ b/source/tap/tracer_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestTracer_collatz(t *testing.T) {
+	tap.ResetTraceID()
 	tracer := tap.NewTracer("test")
 	wat := test.NewWatcher()
 	tracer.SetWatcher(wat)

--- a/source/tap/tracer_test.go
+++ b/source/tap/tracer_test.go
@@ -43,16 +43,16 @@ func TestTracer_collatz(t *testing.T) {
 	assert.Equal(t, recodeTimeField(wat.AllStrings()), []string{
 		"--> t0 [1::1] collatzTest: ",
 		"--> t1 [1:1:2] collatz: 5",
-		"<-- t2 [1:1:2] collatz: 16",
+		"<-- t2 [1:1:2] 16",
 		"--> t3 [1:2:3] collatz: 16",
-		"<-- t4 [1:2:3] collatz: 8",
+		"<-- t4 [1:2:3] 8",
 		"--> t5 [1:3:4] collatz: 8",
-		"<-- t6 [1:3:4] collatz: 4",
+		"<-- t6 [1:3:4] 4",
 		"--> t7 [1:4:5] collatz: 4",
-		"<-- t8 [1:4:5] collatz: 2",
+		"<-- t8 [1:4:5] 2",
 		"--> t9 [1:5:6] collatz: 2",
-		"<-- t10 [1:5:6] collatz: 1",
-		"<-- t11 [1::1] collatzTest: 1",
+		"<-- t10 [1:5:6] 1",
+		"<-- t11 [1::1] 1",
 	})
 }
 

--- a/source/tap/tracer_test.go
+++ b/source/tap/tracer_test.go
@@ -40,7 +40,7 @@ func TestTracer_collatz(t *testing.T) {
 	n := collatz(5, sc)
 	sc.Close(n)
 	require.Equal(t, 1, n)
-	assert.Equal(t, []string{
+	assert.Equal(t, recodeTimeField(wat.AllStrings()), []string{
 		">>> t0 [1::1] collatzTest: ",
 		">>> t1 [1:1:2] collatz: 5",
 		"<<< t2 [1:1:2] collatz: 16",
@@ -53,7 +53,7 @@ func TestTracer_collatz(t *testing.T) {
 		">>> t9 [1:5:6] collatz: 2",
 		"<<< t10 [1:5:6] collatz: 1",
 		"<<< t11 [1::1] collatzTest: 1",
-	}, recodeTimeField(wat.AllStrings()))
+	})
 }
 
 func recodeTimeField(strs []string) []string {


### PR DESCRIPTION
- distinct function return formatting
- less weight to the markers so that they're easier to tell apart
- stop printing the scope name on all except the begin record
- added an id reset function so that ids are predictable when we add more tests
