### PR TITLE
Fix Tracer.Active

### DIFF
--- a/source/tap/tracer.go
+++ b/source/tap/tracer.go
@@ -71,7 +71,7 @@ func (src *Tracer) emit(item interface{}) bool {
 // Active returns true if there any watchers; when not active, all emitted data
 // is dropped.  This should be used by call sites to control scope creation.
 func (src *Tracer) Active() bool {
-	return src.watcher != nil
+	return src.watcher != nil && src.watcher.Active()
 }
 
 // Name returns the gwr source name of the tracer.


### PR DESCRIPTION
Turns out that tracers were never not active, having missed the semantic change pre 0.6 in watcher de-dupe vs activation.

This bug is exercised by an upcoming change to the fib tracer example.
