### PR TITLE
Drop the initial OK response from the redis MONITOR command

### DIFF
--- a/internal/protocol/redis.go
+++ b/internal/protocol/redis.go
@@ -176,10 +176,6 @@ func (rm *respModel) handleMonitor(rconn *resp.RedisConnection, vc *resp.ValueCo
 		return fmt.Errorf("no watches set, monitor likely to be uninteresting")
 	}
 
-	if err := rconn.WriteSimpleString("OK"); err != nil {
-		return err
-	}
-
 	go rm.doWatch(rconn)
 
 	return nil


### PR DESCRIPTION
This make it easier to do things like `redis-cli monitor XXX json | jq .`; previously you had to interject a `tail -n+2`.
