### PR TITLE
Add default stringer text format to marshaled data source

### DIFF
--- a/internal/marshaled/source.go
+++ b/internal/marshaled/source.go
@@ -21,6 +21,7 @@
 package marshaled
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"sort"
@@ -67,6 +68,16 @@ type DataSource struct {
 	itemsChan chan []interface{}
 }
 
+func stringIt(item interface{}) ([]byte, error) {
+	var s string
+	if ss, ok := item.(fmt.Stringer); ok {
+		s = ss.String()
+	} else {
+		s = fmt.Sprintf("%+v", item)
+	}
+	return []byte(s), nil
+}
+
 // NewDataSource creates a DataSource for a given format-agnostic data source
 // and a map of marshalers
 func NewDataSource(
@@ -97,6 +108,11 @@ func NewDataSource(
 				formats["text"] = NewTemplatedMarshal(tt)
 			}
 		}
+	}
+
+	// default to just string-ing it
+	if formats["text"] == nil {
+		formats["text"] = source.GenericDataFormatFunc(stringIt)
 	}
 
 	ds := &DataSource{

--- a/internal/marshaled/source.go
+++ b/internal/marshaled/source.go
@@ -91,9 +91,11 @@ func NewDataSource(
 	}
 
 	// convenience templated text protocol
-	if txtsrc, ok := src.(source.TextTemplatedSource); ok && formats["text"] == nil {
-		if tt := txtsrc.TextTemplate(); tt != nil && formats["text"] == nil {
-			formats["text"] = NewTemplatedMarshal(tt)
+	if formats["text"] == nil {
+		if txtsrc, ok := src.(source.TextTemplatedSource); ok {
+			if tt := txtsrc.TextTemplate(); tt != nil {
+				formats["text"] = NewTemplatedMarshal(tt)
+			}
 		}
 	}
 

--- a/internal/meta/noun_data_source_test.go
+++ b/internal/meta/noun_data_source_test.go
@@ -90,10 +90,10 @@ func TestNounDataSource_Watch(t *testing.T) {
 		tmpl: nil,
 	}, nil)), "no add error expected")
 	assertJSONScanLine(t, sc,
-		`{"name":"/foo","type":"add","info":{"formats":["json"],"attrs":null}}`,
+		`{"name":"/foo","type":"add","info":{"formats":["json","text"],"attrs":null}}`,
 		"should get an add event for /foo")
 	assert.Equal(t, getText(), "Data Sources:\n"+
-		"/foo formats: [json]\n"+
+		"/foo formats: [json text]\n"+
 		"/meta/nouns formats: [json text]\n")
 
 	// add another data source, observe it
@@ -106,7 +106,7 @@ func TestNounDataSource_Watch(t *testing.T) {
 		"should get an add event for /bar")
 	assert.Equal(t, getText(), "Data Sources:\n"+
 		"/bar formats: [json text]\n"+
-		"/foo formats: [json]\n"+
+		"/foo formats: [json text]\n"+
 		"/meta/nouns formats: [json text]\n")
 
 	// remove the /foo data source, observe it


### PR DESCRIPTION
If the generic source defines no template, just stringer-ize things.
