### PR TITLE
Fix example_server access log

### DIFF
--- a/example_server/req_logger.go
+++ b/example_server/req_logger.go
@@ -49,15 +49,12 @@ type reqInfo struct {
 }
 
 func (rl *reqLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if watcher := rl.watcher; watcher != nil {
-		info := reqInfo{
+	if watcher := rl.watcher; watcher.Active() {
+		watcher.HandleItem(reqInfo{
 			Method: r.Method,
 			Path:   r.URL.Path,
 			Query:  r.URL.RawQuery,
-		}
-		if !watcher.HandleItem(info) {
-			rl.watcher = nil
-		}
+		})
 	}
 	rl.handler.ServeHTTP(w, r)
 }

--- a/example_server/res_logger.go
+++ b/example_server/res_logger.go
@@ -44,23 +44,16 @@ var resLogTextTemplate = template.Must(template.New("res_logger_text").Parse(`
 `))
 
 func (rl *resLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	watcher := rl.watcher
-	if watcher == nil {
-		rl.handler.ServeHTTP(w, r)
-		return
-	}
+	rl.watcher.Active()
 
 	rec := httptest.NewRecorder()
 	rl.handler.ServeHTTP(rec, r)
 
-	info := resInfo{
+	rl.watcher.HandleItem(resInfo{
 		Code:        rec.Code,
 		Bytes:       rec.Body.Len(),
 		ContentType: rec.HeaderMap.Get("Content-Type"),
-	}
-	if !watcher.HandleItem(info) {
-		rl.watcher = nil
-	}
+	})
 
 	hdr := w.Header()
 	for key, vals := range rec.HeaderMap {


### PR DESCRIPTION
The example was using the old (pre-0.6.0) style of watcher activation (nilling the watcher).

Looks like this has been broken since first 0.6.0 release since there's no test that runs the example.
